### PR TITLE
ci: Run for master, not main, also enable workflow dispatch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   merge_group:
+  workflow-dispatch:
 
 jobs:
   rustfmt:


### PR DESCRIPTION
With workflow dispatch, an action can be triggered from the Actions page on GitHub.