### PR TITLE
Rework iterable to allow Immutable components refs + placed in any order in the tuple list (same for Optional Components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ This library has not been advertized nor published yet to crates.io for that rea
     - [x] create filter builder
     - [x] add support for optional components
     - [x] add support for parent / instancing matching
-    - [ ] const only components
+    - [x] immutable only components
 - [x] query
     - [x] create query
     - [x] create query builder
     - [x] add support for optional components
     - [x] add support for parent / instancing matching
-    - [ ] const only components
+    - [x] immutable only components
 ```
 
 #### non-core

--- a/flecs_ecs/benches/query.rs
+++ b/flecs_ecs/benches/query.rs
@@ -80,7 +80,7 @@ fn query_each_benchmark(c: &mut Criterion) {
         }
     }
 
-    let mut query = Query::<(Pos, Vel)>::new(&world);
+    let mut query = Query::<(&mut Pos, &Vel)>::new(&world);
 
     c.bench_function("query_each", |b| {
         b.iter(|| {

--- a/flecs_ecs/examples/entity_basics.rs
+++ b/flecs_ecs/examples/entity_basics.rs
@@ -37,7 +37,7 @@ fn main() {
     alice.remove::<Walking>();
 
     // Iterate all entities with position
-    world.each_entity::<(Position,)>(|entity, pos| {
+    world.each_entity::<(&Position,)>(|entity, pos| {
         println!("{} has {:?}", entity.get_name(), pos);
     });
 

--- a/flecs_ecs/examples/entity_hierarchy.rs
+++ b/flecs_ecs/examples/entity_hierarchy.rs
@@ -18,6 +18,8 @@ fn iterate_tree(entity: Entity, position_parent: &Position) {
         entity.get_archetype()
     );
 
+    let option = Some(());
+
     // Get the position of the entity
     let pos = entity.get::<Position>().unwrap();
 

--- a/flecs_ecs/examples/entity_hierarchy.rs
+++ b/flecs_ecs/examples/entity_hierarchy.rs
@@ -18,8 +18,6 @@ fn iterate_tree(entity: Entity, position_parent: &Position) {
         entity.get_archetype()
     );
 
-    let option = Some(());
-
     // Get the position of the entity
     let pos = entity.get::<Position>().unwrap();
 

--- a/flecs_ecs/examples/entity_prefab.rs
+++ b/flecs_ecs/examples/entity_prefab.rs
@@ -55,7 +55,7 @@ fn main() {
     println!("ImpulseSpeed: {}", impulse_speed.unwrap().value);
 
     // Prefab components can be iterated just like regular components:
-    world.each_entity::<(ImpulseSpeed, Position)>(|entity, (impulse_speed, position)| {
+    world.each_entity::<(&ImpulseSpeed, &mut Position)>(|entity, (impulse_speed, position)| {
         position.x += impulse_speed.value;
         println!("Entity {}: {:?}", entity.get_name(), position);
     });

--- a/flecs_ecs/examples/hello_world.rs
+++ b/flecs_ecs/examples/hello_world.rs
@@ -7,7 +7,7 @@ fn main() {
 
     // Register system
     let _sys = world
-        .system_builder::<(Position, Velocity)>()
+        .system_builder::<(&mut Position, &Velocity)>()
         // .on_each_entity if you want the entity to be added in the parameter list
         .on_each(|(pos, vel)| {
             pos.x += vel.x;

--- a/flecs_ecs/examples/query_basics.rs
+++ b/flecs_ecs/examples/query_basics.rs
@@ -1,18 +1,33 @@
 mod common;
 use common::*;
 
+use flecs_ecs::core::enum_type::CachedEnumData;
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Component)]
+enum Colorx {
+    Green,
+    #[default]
+    Red,
+    Blue,
+}
+
 fn main() {
     let world = World::new();
 
     // Create a query for Position, Velocity. Queries are the fastest way to
     // iterate entities as they cache results.
-    let mut query = world.query::<(Position, Velocity)>();
+    let mut query = world.query::<(&mut Position, &Velocity)>();
+    let mut query2 = world.query::<(&mut Position, &Velocity, Option<&Walking>, &Attack)>();
+    let mut query3 = world.query::<(&Walking, &mut Colorx)>();
 
     // Create a few test entities for a Position, Velocity query
     world
         .new_entity_named(CStr::from_bytes_with_nul(b"e1\0").unwrap())
         .set(Position { x: 10.0, y: 20.0 })
-        .set(Velocity { x: 1.0, y: 2.0 });
+        .set(Velocity { x: 1.0, y: 2.0 })
+        .add::<Walking>()
+        .add::<Attack>();
 
     world
         .new_entity_named(CStr::from_bytes_with_nul(b"e2\0").unwrap())
@@ -34,6 +49,16 @@ fn main() {
         println!("{}: [{:?}]", e.get_name(), pos)
     });
 
+    query2.each_entity(|e, (pos, vel, walk, attack)| {
+        println!("q@@@@@@@@@@@@@@@@@@@@@@@");
+        pos.x += vel.x;
+        pos.y += vel.y;
+        println!("{}: [{:?}]", e.get_name(), pos)
+    });
+
+    query3.each_entity(|e, (walk, pos)| {
+        println!("q$$$$$$$$$$$$$$$$$$$");
+    });
     // There's an equivalent function that does not include the entity argument
     query.each(|(pos, vel)| {
         pos.x += vel.x;

--- a/flecs_ecs/examples/query_basics.rs
+++ b/flecs_ecs/examples/query_basics.rs
@@ -1,15 +1,6 @@
 mod common;
 use common::*;
 
-#[repr(C)]
-#[derive(Debug, Default, Clone, Component)]
-enum Colorx {
-    Green,
-    #[default]
-    Red,
-    Blue,
-}
-
 fn main() {
     let world = World::new();
 

--- a/flecs_ecs/examples/query_basics.rs
+++ b/flecs_ecs/examples/query_basics.rs
@@ -1,8 +1,6 @@
 mod common;
 use common::*;
 
-use flecs_ecs::core::enum_type::CachedEnumData;
-
 #[repr(C)]
 #[derive(Debug, Default, Clone, Component)]
 enum Colorx {
@@ -18,16 +16,12 @@ fn main() {
     // Create a query for Position, Velocity. Queries are the fastest way to
     // iterate entities as they cache results.
     let mut query = world.query::<(&mut Position, &Velocity)>();
-    let mut query2 = world.query::<(&mut Position, &Velocity, Option<&Walking>, &Attack)>();
-    let mut query3 = world.query::<(&Walking, &mut Colorx)>();
 
     // Create a few test entities for a Position, Velocity query
     world
         .new_entity_named(CStr::from_bytes_with_nul(b"e1\0").unwrap())
         .set(Position { x: 10.0, y: 20.0 })
-        .set(Velocity { x: 1.0, y: 2.0 })
-        .add::<Walking>()
-        .add::<Attack>();
+        .set(Velocity { x: 1.0, y: 2.0 });
 
     world
         .new_entity_named(CStr::from_bytes_with_nul(b"e2\0").unwrap())
@@ -49,16 +43,6 @@ fn main() {
         println!("{}: [{:?}]", e.get_name(), pos)
     });
 
-    query2.each_entity(|e, (pos, vel, walk, attack)| {
-        println!("q@@@@@@@@@@@@@@@@@@@@@@@");
-        pos.x += vel.x;
-        pos.y += vel.y;
-        println!("{}: [{:?}]", e.get_name(), pos)
-    });
-
-    query3.each_entity(|e, (walk, pos)| {
-        println!("q$$$$$$$$$$$$$$$$$$$");
-    });
     // There's an equivalent function that does not include the entity argument
     query.each(|(pos, vel)| {
         pos.x += vel.x;

--- a/flecs_ecs/src/core/c_types.rs
+++ b/flecs_ecs/src/core/c_types.rs
@@ -392,6 +392,7 @@ fn get_ecs_poly_data() -> ComponentData {
 impl ComponentType<Struct> for EcsComponent {}
 
 impl CachedComponentData for EcsComponent {
+    type UnderlyingType = EcsComponent;
     fn register_explicit(_world: *mut WorldT) {
         //this is already registered as FLECS_IDEcsComponentID_
         Self::__get_once_lock_data().get_or_init(get_ecs_component_data);
@@ -471,6 +472,7 @@ impl Default for Poly {
 impl ComponentType<Struct> for Poly {}
 
 impl CachedComponentData for Poly {
+    type UnderlyingType = Poly;
     fn register_explicit(_world: *mut WorldT) {
         //this is already registered as FLECS_IDEcsComponentID_
         Self::__get_once_lock_data().get_or_init(get_ecs_poly_data);
@@ -778,6 +780,7 @@ impl Default for TickSource {
 }
 
 impl CachedComponentData for TickSource {
+    type UnderlyingType = TickSource;
     fn register_explicit(world: *mut WorldT) {
         try_register_struct_component::<Self>(world);
     }

--- a/flecs_ecs/src/core/component.rs
+++ b/flecs_ecs/src/core/component.rs
@@ -123,12 +123,12 @@ impl UntypedComponent {}
 
 /// Component class.
 /// Class used to register components and component metadata.
-pub struct Component<T: CachedComponentData + Default> {
+pub struct Component<T: CachedComponentData> {
     pub base: UntypedComponent,
     _marker: PhantomData<T>,
 }
 
-impl<T: CachedComponentData + Default> Deref for Component<T> {
+impl<T: CachedComponentData> Deref for Component<T> {
     type Target = UntypedComponent;
 
     fn deref(&self) -> &Self::Target {
@@ -136,7 +136,7 @@ impl<T: CachedComponentData + Default> Deref for Component<T> {
     }
 }
 
-impl<T: CachedComponentData + Default> Component<T> {
+impl<T: CachedComponentData> Component<T> {
     /// Create a new component.
     ///
     /// # Arguments

--- a/flecs_ecs/src/core/component_registration.rs
+++ b/flecs_ecs/src/core/component_registration.rs
@@ -59,7 +59,9 @@ pub trait ComponentType<T: ECSComponentType>: CachedComponentData {}
 /// If the world doesn't, this implies the component was registered by a different world.
 /// In such a case, the component is registered with the present world using the pre-existing ID.
 /// If the ID is already known, the trait takes care of the component registration and checks for consistency in the input.
-pub trait CachedComponentData: Clone + Default {
+pub trait CachedComponentData: Sized {
+    type UnderlyingType: CachedComponentData + Default + Clone;
+
     /// attempts to register the component with the world. If it's already registered, it does nothing.
     fn register_explicit(world: *mut WorldT);
 
@@ -314,7 +316,7 @@ fn register_componment_data_explicit<T>(
     is_comp_pre_registered: bool,
 ) -> bool
 where
-    T: CachedComponentData + Clone + Default,
+    T: CachedComponentData,
 {
     let mut component_data: ComponentData = Default::default();
     if is_comp_pre_registered {
@@ -420,7 +422,7 @@ pub(crate) fn register_entity_w_component_explicit<T>(
     id: EntityT,
 ) -> EntityT
 where
-    T: CachedComponentData + Clone + Default,
+    T: CachedComponentData,
 {
     let is_comp_pre_registered = T::is_registered();
     let mut component_data: ComponentData = Default::default();
@@ -530,7 +532,7 @@ pub(crate) fn register_component_data<T>(
     is_comp_pre_registered_with_world: bool,
 ) -> bool
 where
-    T: CachedComponentData + Clone + Default,
+    T: CachedComponentData,
 {
     let mut has_registered = false;
     //this is safe because we checked if the component is pre-registered
@@ -559,7 +561,9 @@ where
             // Register lifecycle callbacks, but only if the component has a
             // size. Components that don't have a size are tags, and tags don't
             // require construction/destruction/copy/move's.
-            register_lifecycle_actions::<T>(world, unsafe { T::get_id_unchecked() });
+            register_lifecycle_actions::<T::UnderlyingType>(world, unsafe {
+                T::get_id_unchecked()
+            });
         }
 
         if prev_with != 0 {

--- a/flecs_ecs/src/core/component_registration.rs
+++ b/flecs_ecs/src/core/component_registration.rs
@@ -81,7 +81,7 @@ pub trait CachedComponentData: Sized {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn is_registered_with_world(world: *mut WorldT) -> bool {
         if Self::is_registered() {
-            unsafe { is_component_registered_with_world::<Self>(world) }
+            unsafe { is_component_registered_with_world::<Self::UnderlyingType>(world) }
         } else {
             false
         }

--- a/flecs_ecs/src/core/entity.rs
+++ b/flecs_ecs/src/core/entity.rs
@@ -1625,7 +1625,9 @@ impl Entity {
     ///
     /// * C++ API: `entity::get_mut`
     #[doc(alias = "entity::get_mut")]
-    pub fn get_mut<T: CachedComponentData + ComponentType<Struct>>(&self) -> Option<&mut T> {
+    pub fn get_mut<T: CachedComponentData + ComponentType<Struct>>(
+        &self,
+    ) -> Option<&mut T::UnderlyingType> {
         let component_id = T::get_id(self.world);
         ecs_assert!(
             T::get_size(self.world) != 0,
@@ -1633,7 +1635,10 @@ impl Entity {
             "invalid type: {}",
             T::get_symbol_name()
         );
-        unsafe { (ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T).as_mut() }
+        unsafe {
+            (ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T::UnderlyingType)
+                .as_mut()
+        }
     }
 
     /// Gets mut component unchecked
@@ -1661,7 +1666,7 @@ impl Entity {
     #[doc(alias = "entity::get_mut")]
     pub unsafe fn get_unchecked_mut<T: CachedComponentData + ComponentType<Struct>>(
         &mut self,
-    ) -> &mut T {
+    ) -> &mut T::UnderlyingType {
         let component_id = T::get_id(self.world);
         ecs_assert!(
             T::get_size(self.world) != 0,
@@ -1669,7 +1674,7 @@ impl Entity {
             "invalid type: {}",
             T::get_symbol_name()
         );
-        let ptr = ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T;
+        let ptr = ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T::UnderlyingType;
         ecs_assert!(
             !ptr.is_null(),
             FlecsErrorCode::InternalError,
@@ -1695,17 +1700,23 @@ impl Entity {
     ///
     /// * C++ API: `entity::get_mut`
     #[doc(alias = "entity::get_mut")]
-    pub fn get_enum_mut<T: CachedComponentData + ComponentType<Enum>>(&self) -> Option<&mut T> {
+    pub fn get_enum_mut<T: CachedComponentData + ComponentType<Enum>>(
+        &self,
+    ) -> Option<&mut T::UnderlyingType> {
         let component_id: IdT = T::get_id(self.world);
         let target: IdT = unsafe { ecs_get_target(self.world, self.raw_id, component_id, 0) };
 
         if target == 0 {
             // if there is no matching pair for (r,*), try just r
-            unsafe { (ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T).as_mut() }
+            unsafe {
+                (ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T::UnderlyingType)
+                    .as_mut()
+            }
         } else {
             // get constant value from constant entity
-            let constant_value =
-                unsafe { ecs_get_mut_id(self.world, target, component_id) as *mut T };
+            let constant_value = unsafe {
+                ecs_get_mut_id(self.world, target, component_id) as *mut T::UnderlyingType
+            };
 
             ecs_assert!(
                 !constant_value.is_null(),
@@ -1738,13 +1749,14 @@ impl Entity {
     #[doc(alias = "entity::get_mut")]
     pub unsafe fn get_enum_unchecked_mut<T: CachedComponentData + ComponentType<Enum>>(
         &mut self,
-    ) -> &mut T {
+    ) -> &mut T::UnderlyingType {
         let component_id: IdT = T::get_id(self.world);
         let target: IdT = ecs_get_target(self.world, self.raw_id, component_id, 0);
 
         if target == 0 {
             // if there is no matching pair for (r,*), try just r
-            let ptr = ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T;
+            let ptr =
+                ecs_get_mut_id(self.world, self.raw_id, component_id) as *mut T::UnderlyingType;
             ecs_assert!(
                 !ptr.is_null(),
                 FlecsErrorCode::InternalError,
@@ -1755,7 +1767,8 @@ impl Entity {
             &mut *ptr
         } else {
             // get constant value from constant entity
-            let constant_value = ecs_get_mut_id(self.world, target, component_id) as *mut T;
+            let constant_value =
+                ecs_get_mut_id(self.world, target, component_id) as *mut T::UnderlyingType;
             ecs_assert!(
                 !constant_value.is_null(),
                 FlecsErrorCode::InternalError,
@@ -2026,8 +2039,8 @@ impl Entity {
     ///
     /// * C++ API: `entity::get_ref`
     #[doc(alias = "entity::get_ref")]
-    pub fn get_ref_component<T: CachedComponentData>(&self) -> Ref<T> {
-        Ref::<T>::new(self.world, self.raw_id, T::get_id(self.world))
+    pub fn get_ref_component<T: CachedComponentData>(&self) -> Ref<T::UnderlyingType> {
+        Ref::<T::UnderlyingType>::new(self.world, self.raw_id, T::get_id(self.world))
     }
 
     /// Get a reference to the first component of pair

--- a/flecs_ecs/src/core/entity_view.rs
+++ b/flecs_ecs/src/core/entity_view.rs
@@ -635,9 +635,13 @@ impl EntityView {
     ///
     /// * C++ API: `entity_view::get`
     #[doc(alias = "entity_view::get")]
-    pub fn get<T: CachedComponentData + ComponentType<Struct>>(&self) -> Option<&T> {
+    pub fn get<T: CachedComponentData + ComponentType<Struct>>(
+        &self,
+    ) -> Option<&T::UnderlyingType> {
         let component_id = T::get_id(self.world);
-        unsafe { (ecs_get_id(self.world, self.raw_id, component_id) as *const T).as_ref() }
+        unsafe {
+            (ecs_get_id(self.world, self.raw_id, component_id) as *const T::UnderlyingType).as_ref()
+        }
     }
 
     /// Get (struct) Component from entity unchecked
@@ -658,9 +662,11 @@ impl EntityView {
     ///
     /// * C++ API: `entity_view::get`
     #[doc(alias = "entity_view::get")]
-    pub unsafe fn get_unchecked<T: CachedComponentData + ComponentType<Struct>>(&self) -> &T {
+    pub unsafe fn get_unchecked<T: CachedComponentData + ComponentType<Struct>>(
+        &self,
+    ) -> &T::UnderlyingType {
         let component_id = T::get_id(self.world);
-        let ptr = ecs_get_id(self.world, self.raw_id, component_id) as *const T;
+        let ptr = ecs_get_id(self.world, self.raw_id, component_id) as *const T::UnderlyingType;
         ecs_assert!(
             !ptr.is_null(),
             FlecsErrorCode::InternalError,
@@ -685,17 +691,22 @@ impl EntityView {
     ///
     /// * C++ API: `entity_view::get`
     #[doc(alias = "entity_view::get")]
-    pub fn get_enum<T: CachedComponentData + ComponentType<Enum>>(&self) -> Option<&T> {
+    pub fn get_enum<T: CachedComponentData + ComponentType<Enum>>(
+        &self,
+    ) -> Option<&T::UnderlyingType> {
         let component_id: IdT = T::get_id(self.world);
         let target: IdT = unsafe { ecs_get_target(self.world, self.raw_id, component_id, 0) };
 
         if target == 0 {
             // if there is no matching pair for (r,*), try just r
-            unsafe { (ecs_get_id(self.world, self.raw_id, component_id) as *const T).as_ref() }
+            unsafe {
+                (ecs_get_id(self.world, self.raw_id, component_id) as *const T::UnderlyingType)
+                    .as_ref()
+            }
         } else {
             // get constant value from constant entity
             let constant_value =
-                unsafe { ecs_get_id(self.world, target, component_id) as *const T };
+                unsafe { ecs_get_id(self.world, target, component_id) as *const T::UnderlyingType };
 
             ecs_assert!(
                 !constant_value.is_null(),
@@ -726,13 +737,15 @@ impl EntityView {
     ///
     /// * C++ API: `entity_view::get`
     #[doc(alias = "entity_view::get")]
-    pub unsafe fn get_enum_unchecked<T: CachedComponentData + ComponentType<Enum>>(&self) -> &T {
+    pub unsafe fn get_enum_unchecked<T: CachedComponentData + ComponentType<Enum>>(
+        &self,
+    ) -> &T::UnderlyingType {
         let component_id: IdT = T::get_id(self.world);
         let target: IdT = ecs_get_target(self.world, self.raw_id, component_id, 0);
 
         if target == 0 {
             // if there is no matching pair for (r,*), try just r
-            let ptr = ecs_get_id(self.world, self.raw_id, component_id) as *const T;
+            let ptr = ecs_get_id(self.world, self.raw_id, component_id) as *const T::UnderlyingType;
             ecs_assert!(
                 !ptr.is_null(),
                 FlecsErrorCode::InternalError,
@@ -742,7 +755,8 @@ impl EntityView {
             &*ptr
         } else {
             // get constant value from constant entity
-            let constant_value = ecs_get_id(self.world, target, component_id) as *const T;
+            let constant_value =
+                ecs_get_id(self.world, target, component_id) as *const T::UnderlyingType;
             ecs_assert!(
                 !constant_value.is_null(),
                 FlecsErrorCode::InternalError,

--- a/flecs_ecs/src/core/iter.rs
+++ b/flecs_ecs/src/core/iter.rs
@@ -157,7 +157,7 @@ impl<'a> Iter<'a> {
     ///
     /// * C++ API: `iter::type`
     #[doc(alias = "iter::type")]
-    pub fn get_type(&self) -> Archetype {
+    pub fn get_archetype(&self) -> Archetype {
         unsafe { Archetype::new(self.iter.world, ecs_table_get_type(self.iter.table)) }
     }
 

--- a/flecs_ecs/src/core/iterable.rs
+++ b/flecs_ecs/src/core/iterable.rs
@@ -1,7 +1,7 @@
 use super::{
     c_binding::{
         bindings::{ecs_filter_desc_t, ecs_oper_kind_t},
-        ecs_inout_kind_t, ecs_term_t,
+        ecs_inout_kind_t,
     },
     c_types::{IterT, OperKind, TermT, WorldT},
     component_registration::CachedComponentData,

--- a/flecs_ecs/src/core/query.rs
+++ b/flecs_ecs/src/core/query.rs
@@ -113,7 +113,7 @@ where
     ///
     /// * C++ API: `query_base::changed`
     #[doc(alias = "query_base::changed")]
-    pub fn changed(&mut self) -> bool {
+    pub fn is_changed(&self) -> bool {
         unsafe { ecs_query_changed(self.query, std::ptr::null()) }
     }
 
@@ -130,7 +130,7 @@ where
     ///
     /// * C++ API: `query_base::orphaned`
     #[doc(alias = "query_base::orphaned")]
-    pub fn orphaned(&mut self) -> bool {
+    pub fn is_orphaned(&mut self) -> bool {
         unsafe { ecs_query_orphaned(self.query) }
     }
 
@@ -533,8 +533,10 @@ where
         unsafe {
             let mut iter = ecs_query_iter(self.world.raw_world, self.query);
             while ecs_query_next(&mut iter) {
+                ecs_table_lock(self.world.raw_world, iter.table);
                 let mut iter_t = Iter::new(&mut iter);
                 func(&mut iter_t);
+                ecs_table_unlock(self.world.raw_world, iter.table);
             }
         }
     }

--- a/flecs_ecs/src/core/table.rs
+++ b/flecs_ecs/src/core/table.rs
@@ -446,9 +446,11 @@ impl Table {
     ///
     /// * C++ API: `table::get`
     #[doc(alias = "table::get")]
-    pub fn get_component_array_ptr<T: CachedComponentData>(&self) -> Option<*mut T> {
+    pub fn get_component_array_slice<T: CachedComponentData>(&self) -> Option<&mut [T]> {
         self.get_component_array_ptr_id(T::get_id(self.world))
-            .map(|ptr| ptr as *mut T)
+            .map(|ptr| unsafe {
+                std::slice::from_raw_parts_mut(ptr as *mut T, self.get_count() as usize)
+            })
     }
 
     /// Get column, components array ptr from table by component type.

--- a/flecs_ecs/src/core/term.rs
+++ b/flecs_ecs/src/core/term.rs
@@ -476,24 +476,40 @@ pub trait TermBuilder: Sized {
         self
     }
 
+    /// default up where trav is set to 0.
+    /// The up flag indicates that the term identifier may be substituted by
+    /// traversing a relationship upwards. For example: substitute the identifier
+    /// with its parent by traversing the `ChildOf` relationship.
+    ///
+    /// # See also
+    ///
+    /// * C++ API: `term_builder_i::up`
+    #[doc(alias = "term_builder_i::up")]
+    fn up(&mut self) -> &mut Self {
+        self.assert_term_id();
+        unsafe {
+            (*self.get_term_id()).flags |= ECS_UP;
+            (*self.get_term_id()).trav = 0;
+        };
+        self
+    }
+
     /// The up flag indicates that the term identifier may be substituted by
     /// traversing a relationship upwards. For example: substitute the identifier
     /// with its parent by traversing the `ChildOf` relationship.
     ///
     /// # Arguments
     ///
-    /// * `traverse_relationship` - The optional relationship to traverse.
+    /// * `traverse_relationship` - The relationship to traverse.
     ///
     /// # See also
     ///
     /// * C++ API: `term_builder_i::up`
     #[doc(alias = "term_builder_i::up")]
-    fn up_id(&mut self, traverse_relationship: Option<EntityT>) -> &mut Self {
+    fn up_id(&mut self, traverse_relationship: EntityT) -> &mut Self {
         self.assert_term_id();
         unsafe { (*self.get_term_id()).flags |= ECS_UP };
-        if let Some(trav_rel) = traverse_relationship {
-            unsafe { (*self.get_term_id()).trav = trav_rel };
-        }
+        unsafe { (*self.get_term_id()).trav = traverse_relationship };
         self
     }
 
@@ -509,7 +525,7 @@ pub trait TermBuilder: Sized {
     ///
     /// * C++ API: `term_builder_i::up`
     #[doc(alias = "term_builder_i::up")]
-    fn up<TravRel: CachedComponentData>(&mut self) -> &mut Self {
+    fn up_type<TravRel: CachedComponentData>(&mut self) -> &mut Self {
         self.assert_term_id();
         unsafe {
             (*self.get_term_id()).flags |= ECS_UP;

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -1084,7 +1084,7 @@ impl World {
     /// * C++ API: `world::get_ref`
     #[doc(alias = "world::get_ref")]
     #[inline(always)]
-    pub fn get_ref_component<T>(&self) -> Ref<T>
+    pub fn get_ref_component<T>(&self) -> Ref<T::UnderlyingType>
     where
         T: CachedComponentData,
     {
@@ -3059,8 +3059,11 @@ impl World {
     ///
     /// * C++ API: `world::component`
     #[doc(alias = "world::component")]
-    pub fn component_named<T: CachedComponentData>(&self, name: &CStr) -> Component<T> {
-        Component::<T>::new_named(self, name)
+    pub fn component_named<T: CachedComponentData>(
+        &self,
+        name: &CStr,
+    ) -> Component<T::UnderlyingType> {
+        Component::<T::UnderlyingType>::new_named(self, name)
     }
 
     /// Find or register untyped component.

--- a/flecs_ecs/src/core/world.rs
+++ b/flecs_ecs/src/core/world.rs
@@ -3037,8 +3037,8 @@ impl World {
     ///
     /// * C++ API: `world::component`
     #[doc(alias = "world::component")]
-    pub fn component<T: CachedComponentData>(&self) -> Component<T> {
-        Component::<T>::new(self)
+    pub fn component<T: CachedComponentData>(&self) -> Component<T::UnderlyingType> {
+        Component::<T::UnderlyingType>::new(self)
     }
 
     /// Find or register component.

--- a/flecs_ecs/tests/common.rs
+++ b/flecs_ecs/tests/common.rs
@@ -1,4 +1,4 @@
-use flecs_ecs::core::{c_types::*, component_registration::*};
+use flecs_ecs::core::component_registration::*;
 use flecs_ecs_derive::Component;
 
 #[cfg(test)]

--- a/flecs_ecs_derive/src/lib.rs
+++ b/flecs_ecs_derive/src/lib.rs
@@ -77,50 +77,50 @@ fn impl_cached_component_data_struct(
     };
 
     let cached_component_data_impl = quote! {
-        fn register_explicit(world: *mut WorldT)
+        fn register_explicit(world: *mut flecs_ecs::core::WorldT)
         {
-            try_register_struct_component::<Self>(world);
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
         }
 
-        fn register_explicit_named(world: *mut WorldT, name: &std::ffi::CStr)
+        fn register_explicit_named(world: *mut flecs_ecs::core::WorldT, name: &std::ffi::CStr)
         {
             use std::ffi::CStr;
-            try_register_struct_component_named::<Self>(world, name);
+            flecs_ecs::core::try_register_struct_component_named::<Self>(world, name);
         }
 
-        fn get_data(world: *mut WorldT) -> &'static ComponentData
+        fn get_data(world: *mut flecs_ecs::core::WorldT) -> &'static flecs_ecs::core::ComponentData
         {
-            try_register_struct_component::<Self>(world);
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
             //this is safe because we checked if the component is registered / registered it
             unsafe { Self::get_data_unchecked() }
         }
 
-        fn get_id(world: *mut WorldT) -> IdT {
-            try_register_struct_component::<Self>(world);
+        fn get_id(world: *mut flecs_ecs::core::WorldT) ->  flecs_ecs::core::IdT {
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
             //this is safe because we checked if the component is registered / registered it
             unsafe { Self::get_id_unchecked() }
         }
 
-        fn get_size(world: *mut WorldT) -> usize {
-            try_register_struct_component::<Self>(world);
+        fn get_size(world: *mut flecs_ecs::core::WorldT) -> usize {
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
             //this is safe because we checked if the component is registered / registered it
             unsafe { Self::get_size_unchecked() }
         }
 
-        fn get_alignment(world: *mut WorldT) -> usize {
-            try_register_struct_component::<Self>(world);
+        fn get_alignment(world: *mut flecs_ecs::core::WorldT) -> usize {
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
             //this is safe because we checked if the component is registered / registered it
             unsafe { Self::get_alignment_unchecked() }
         }
 
-        fn get_allow_tag(world: *mut WorldT) -> bool {
-            try_register_struct_component::<Self>(world);
+        fn get_allow_tag(world: *mut flecs_ecs::core::WorldT) -> bool {
+            flecs_ecs::core::try_register_struct_component::<Self>(world);
             //this is safe because we checked if the component is registered / registered it
             unsafe { Self::get_allow_tag_unchecked() }
         }
 
-        fn __get_once_lock_data() -> &'static std::sync::OnceLock<ComponentData> {
-            static ONCE_LOCK: std::sync::OnceLock<ComponentData> = std::sync::OnceLock::new();
+        fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::ComponentData> {
+            static ONCE_LOCK: std::sync::OnceLock<flecs_ecs::core::ComponentData> = std::sync::OnceLock::new();
             &ONCE_LOCK
         }
 
@@ -141,31 +141,102 @@ fn impl_cached_component_data_struct(
             &name[..name.len() - 1]
         }
     };
+
+    let cached_component_data_impl_ref = quote! {
+        fn register_explicit(world: *mut flecs_ecs::core::WorldT)
+        {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+        }
+
+        fn register_explicit_named(world: *mut flecs_ecs::core::WorldT, name: &std::ffi::CStr)
+        {
+            use std::ffi::CStr;
+            flecs_ecs::core::try_register_struct_component_named::<Self::UnderlyingType>(world, name);
+        }
+
+        fn get_data(world: *mut flecs_ecs::core::WorldT) -> &'static flecs_ecs::core::ComponentData
+        {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_data_unchecked() }
+        }
+
+        fn get_id(world: *mut flecs_ecs::core::WorldT) ->  flecs_ecs::core::IdT {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_id_unchecked() }
+        }
+
+        fn get_size(world: *mut flecs_ecs::core::WorldT) -> usize {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_size_unchecked() }
+        }
+
+        fn get_alignment(world: *mut flecs_ecs::core::WorldT) -> usize {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_alignment_unchecked() }
+        }
+
+        fn get_allow_tag(world: *mut flecs_ecs::core::WorldT) -> bool {
+            flecs_ecs::core::try_register_struct_component::<Self::UnderlyingType>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_allow_tag_unchecked() }
+        }
+
+        fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::ComponentData> {
+            Self::UnderlyingType::__get_once_lock_data()
+        }
+
+        // Function for C compatibility, returns null-terminated string.
+        fn get_symbol_name_c() -> &'static str {
+            Self::UnderlyingType::get_symbol_name_c()
+        }
+
+        // Function to return a &str slice without the null termination for Rust.
+        fn get_symbol_name() -> &'static str {
+            Self::UnderlyingType::get_symbol_name()
+        }
+
+        fn __initialize<F: FnOnce() -> ComponentData>(f: F) -> &'static ComponentData {
+            Self::UnderlyingType::__get_once_lock_data().get_or_init(f)
+        }
+
+        unsafe fn get_data_unchecked() -> &'static ComponentData {
+            Self::UnderlyingType::__get_once_lock_data().get().unwrap_unchecked()
+        }
+
+        fn is_registered() -> bool {
+            Self::UnderlyingType::__get_once_lock_data().get().is_some()
+        }
+    };
+
     // Common trait implementation for ComponentType and CachedComponentData
     let common_traits = quote! {
-        impl ComponentType<Struct> for #name {}
+        impl flecs_ecs::core::ComponentType<flecs_ecs::core::Struct> for #name {}
 
-        impl CachedComponentData for #name {
+        impl flecs_ecs::core::CachedComponentData for #name {
             type UnderlyingType = #name;
             #cached_component_data_impl
         }
 
-        impl CachedComponentData for &#name {
+        impl flecs_ecs::core::CachedComponentData for &#name {
             type UnderlyingType = #name;
-            #cached_component_data_impl
+            #cached_component_data_impl_ref
         }
 
-        impl CachedComponentData for &mut #name {
+        impl flecs_ecs::core::CachedComponentData for &mut #name {
             type UnderlyingType = #name;
-            #cached_component_data_impl
+            #cached_component_data_impl_ref
         }
     };
 
     // Specific trait implementation based on the presence of fields
     let specific_trait = if has_fields {
-        quote! { impl NotEmptyComponent for #name {} }
+        quote! { impl flecs_ecs::core::NotEmptyComponent for #name {} }
     } else {
-        quote! { impl EmptyComponent for #name {} }
+        quote! { impl flecs_ecs::core::EmptyComponent for #name {} }
     };
 
     // Combine common and specific trait implementations
@@ -279,7 +350,7 @@ fn impl_cached_component_data_enum(ast: &syn::DeriveInput) -> TokenStream {
     let has_variants = !variants.is_empty();
     let size_variants = variants.len() as u32;
     let not_empty_trait_or_error = if has_variants {
-        quote! { impl NotEmptyComponent for #name {} }
+        quote! { impl flecs_ecs::core::NotEmptyComponent for #name {} }
     } else {
         quote! { compile_error!("Enum components should have at least one variant!"); }
     };
@@ -311,56 +382,56 @@ fn impl_cached_component_data_enum(ast: &syn::DeriveInput) -> TokenStream {
     };
 
     let cached_enum_data = quote! {
-        impl CachedEnumData for #name {
+        impl flecs_ecs::core::enum_type::CachedEnumData for #name {
             #cached_enum_data_impl
         }
 
     };
     let cached_component_data_impl = quote! {
-        fn register_explicit(world: *mut WorldT)
+        fn register_explicit(world: *mut flecs_ecs::core::WorldT)
             {
-                try_register_enum_component::<Self>(world);
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
             }
 
-            fn register_explicit_named(world: *mut WorldT, name: &std::ffi::CStr)
+            fn register_explicit_named(world: *mut flecs_ecs::core::WorldT, name: &std::ffi::CStr)
             {
                 use std::ffi::CStr;
-                try_register_enum_component_named::<Self>(world, name);
+                flecs_ecs::core::try_register_enum_component_named::<Self>(world, name);
             }
 
-            fn get_data(world: *mut WorldT) -> &'static ComponentData
+            fn get_data(world: *mut flecs_ecs::core::WorldT) -> &'static flecs_ecs::core::ComponentData
             {
-                try_register_enum_component::<Self>(world);
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
                 //this is safe because we checked if the component is registered / registered it
                 unsafe { Self::get_data_unchecked() }
             }
 
-            fn get_id(world: *mut WorldT) -> IdT {
-                try_register_enum_component::<Self>(world);
+            fn get_id(world: *mut flecs_ecs::core::WorldT) ->  flecs_ecs::core::IdT {
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
                 //this is safe because we checked if the component is registered / registered it
                 unsafe { Self::get_id_unchecked() }
             }
 
-            fn get_size(world: *mut WorldT) -> usize {
-                try_register_enum_component::<Self>(world);
+            fn get_size(world: *mut flecs_ecs::core::WorldT) -> usize {
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
                 //this is safe because we checked if the component is registered / registered it
                 unsafe { Self::get_size_unchecked() }
             }
 
-            fn get_alignment(world: *mut WorldT) -> usize {
-                try_register_enum_component::<Self>(world);
+            fn get_alignment(world: *mut flecs_ecs::core::WorldT) -> usize {
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
                 //this is safe because we checked if the component is registered / registered it
                 unsafe { Self::get_alignment_unchecked() }
             }
 
-            fn get_allow_tag(world: *mut WorldT) -> bool {
-                try_register_enum_component::<Self>(world);
+            fn get_allow_tag(world: *mut flecs_ecs::core::WorldT) -> bool {
+                flecs_ecs::core::try_register_enum_component::<Self>(world);
                 //this is safe because we checked if the component is registered / registered it
                 unsafe { Self::get_allow_tag_unchecked() }
             }
 
-            fn __get_once_lock_data() -> &'static std::sync::OnceLock<ComponentData> {
-                static ONCE_LOCK: std::sync::OnceLock<ComponentData> = std::sync::OnceLock::new();
+            fn __get_once_lock_data() -> &'static std::sync::OnceLock<flecs_ecs::core::ComponentData> {
+                static ONCE_LOCK: std::sync::OnceLock<flecs_ecs::core::ComponentData> = std::sync::OnceLock::new();
                 &ONCE_LOCK
             }
 
@@ -383,9 +454,9 @@ fn impl_cached_component_data_enum(ast: &syn::DeriveInput) -> TokenStream {
     };
 
     quote! {
-        impl ComponentType<Enum> for #name {}
+        impl flecs_ecs::core::ComponentType<flecs_ecs::core::Enum> for #name {}
 
-        impl CachedComponentData for #name {
+        impl flecs_ecs::core::CachedComponentData for #name {
             type UnderlyingType = #name;
             #cached_component_data_impl
         }

--- a/flecs_ecs_derive/src/lib.rs
+++ b/flecs_ecs_derive/src/lib.rs
@@ -76,75 +76,88 @@ fn impl_cached_component_data_struct(
         Fields::Unit => false,
     };
 
+    let cached_component_data_impl = quote! {
+        fn register_explicit(world: *mut WorldT)
+        {
+            try_register_struct_component::<Self>(world);
+        }
+
+        fn register_explicit_named(world: *mut WorldT, name: &std::ffi::CStr)
+        {
+            use std::ffi::CStr;
+            try_register_struct_component_named::<Self>(world, name);
+        }
+
+        fn get_data(world: *mut WorldT) -> &'static ComponentData
+        {
+            try_register_struct_component::<Self>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_data_unchecked() }
+        }
+
+        fn get_id(world: *mut WorldT) -> IdT {
+            try_register_struct_component::<Self>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_id_unchecked() }
+        }
+
+        fn get_size(world: *mut WorldT) -> usize {
+            try_register_struct_component::<Self>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_size_unchecked() }
+        }
+
+        fn get_alignment(world: *mut WorldT) -> usize {
+            try_register_struct_component::<Self>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_alignment_unchecked() }
+        }
+
+        fn get_allow_tag(world: *mut WorldT) -> bool {
+            try_register_struct_component::<Self>(world);
+            //this is safe because we checked if the component is registered / registered it
+            unsafe { Self::get_allow_tag_unchecked() }
+        }
+
+        fn __get_once_lock_data() -> &'static std::sync::OnceLock<ComponentData> {
+            static ONCE_LOCK: std::sync::OnceLock<ComponentData> = std::sync::OnceLock::new();
+            &ONCE_LOCK
+        }
+
+        // Function for C compatibility, returns null-terminated string.
+        fn get_symbol_name_c() -> &'static str {
+            use std::any::type_name;
+            static SYMBOL_NAME_C: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+            SYMBOL_NAME_C.get_or_init(|| {
+                let mut name = type_name::<Self>().replace("::", ".");
+                name.push('\0');  // Add null terminator to make it C compatible.
+                name
+            })
+        }
+
+        // Function to return a &str slice without the null termination for Rust.
+        fn get_symbol_name() -> &'static str {
+            let name = Self::get_symbol_name_c();
+            &name[..name.len() - 1]
+        }
+    };
     // Common trait implementation for ComponentType and CachedComponentData
     let common_traits = quote! {
         impl ComponentType<Struct> for #name {}
 
         impl CachedComponentData for #name {
+            type UnderlyingType = #name;
+            #cached_component_data_impl
+        }
 
-            fn register_explicit(world: *mut WorldT)
-            {
-                try_register_struct_component::<Self>(world);
-            }
+        impl CachedComponentData for &#name {
+            type UnderlyingType = #name;
+            #cached_component_data_impl
+        }
 
-            fn register_explicit_named(world: *mut WorldT, name: &std::ffi::CStr)
-            {
-                use std::ffi::CStr;
-                try_register_struct_component_named::<Self>(world, name);
-            }
-
-            fn get_data(world: *mut WorldT) -> &'static ComponentData
-            {
-                try_register_struct_component::<Self>(world);
-                //this is safe because we checked if the component is registered / registered it
-                unsafe { Self::get_data_unchecked() }
-            }
-
-            fn get_id(world: *mut WorldT) -> IdT {
-                try_register_struct_component::<Self>(world);
-                //this is safe because we checked if the component is registered / registered it
-                unsafe { Self::get_id_unchecked() }
-            }
-
-            fn get_size(world: *mut WorldT) -> usize {
-                try_register_struct_component::<Self>(world);
-                //this is safe because we checked if the component is registered / registered it
-                unsafe { Self::get_size_unchecked() }
-            }
-
-            fn get_alignment(world: *mut WorldT) -> usize {
-                try_register_struct_component::<Self>(world);
-                //this is safe because we checked if the component is registered / registered it
-                unsafe { Self::get_alignment_unchecked() }
-            }
-
-            fn get_allow_tag(world: *mut WorldT) -> bool {
-                try_register_struct_component::<Self>(world);
-                //this is safe because we checked if the component is registered / registered it
-                unsafe { Self::get_allow_tag_unchecked() }
-            }
-
-            fn __get_once_lock_data() -> &'static std::sync::OnceLock<ComponentData> {
-                static ONCE_LOCK: std::sync::OnceLock<ComponentData> = std::sync::OnceLock::new();
-                &ONCE_LOCK
-            }
-
-            // Function for C compatibility, returns null-terminated string.
-            fn get_symbol_name_c() -> &'static str {
-                use std::any::type_name;
-                static SYMBOL_NAME_C: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-                SYMBOL_NAME_C.get_or_init(|| {
-                    let mut name = type_name::<Self>().replace("::", ".");
-                    name.push('\0');  // Add null terminator to make it C compatible.
-                    name
-                })
-            }
-
-            // Function to return a &str slice without the null termination for Rust.
-            fn get_symbol_name() -> &'static str {
-                let name = Self::get_symbol_name_c();
-                &name[..name.len() - 1]
-            }
+        impl CachedComponentData for &mut #name {
+            type UnderlyingType = #name;
+            #cached_component_data_impl
         }
     };
 
@@ -271,40 +284,40 @@ fn impl_cached_component_data_enum(ast: &syn::DeriveInput) -> TokenStream {
         quote! { compile_error!("Enum components should have at least one variant!"); }
     };
 
-    let cached_enum_data = quote! {
-        impl CachedEnumData for #name {
-            const SIZE_ENUM_FIELDS: u32 = #size_variants;
-            type VariantIterator = std::vec::IntoIter<#name>;
+    let cached_enum_data_impl = quote! {
+        const SIZE_ENUM_FIELDS: u32 = #size_variants;
+        type VariantIterator = std::vec::IntoIter<#name>;
 
-            fn get_cstr_name(&self) -> &std::ffi::CStr {
-                match self {
-                    #(#variant_name_arms),*
-                }
+        fn get_cstr_name(&self) -> &std::ffi::CStr {
+            match self {
+                #(#variant_name_arms),*
             }
+        }
 
-            fn get_enum_index(&self) -> usize {
-                match self {
-                    #(#variant_index_arms),*
-                }
+        fn get_enum_index(&self) -> usize {
+            match self {
+                #(#variant_index_arms),*
             }
+        }
 
-            fn __get_enum_data_ptr_mut() -> *mut u64 {
-                static mut ENUM_FIELD_ENTITY_ID: [u64; #size_variants as usize] = [0; #size_variants as usize];
-                unsafe { ENUM_FIELD_ENTITY_ID.as_mut_ptr() }
-            }
+        fn __get_enum_data_ptr_mut() -> *mut u64 {
+            static mut ENUM_FIELD_ENTITY_ID: [u64; #size_variants as usize] = [0; #size_variants as usize];
+            unsafe { ENUM_FIELD_ENTITY_ID.as_mut_ptr() }
+        }
 
-            fn iter() -> Self::VariantIterator {
-                vec![#(#variant_constructors),*].into_iter()
-            }
+        fn iter() -> Self::VariantIterator {
+            vec![#(#variant_constructors),*].into_iter()
         }
     };
 
-    quote! {
-        impl ComponentType<Enum> for #name {}
+    let cached_enum_data = quote! {
+        impl CachedEnumData for #name {
+            #cached_enum_data_impl
+        }
 
-        impl CachedComponentData for #name {
-
-            fn register_explicit(world: *mut WorldT)
+    };
+    let cached_component_data_impl = quote! {
+        fn register_explicit(world: *mut WorldT)
             {
                 try_register_enum_component::<Self>(world);
             }
@@ -367,6 +380,14 @@ fn impl_cached_component_data_enum(ast: &syn::DeriveInput) -> TokenStream {
                 let name = Self::get_symbol_name_c();
                 &name[..name.len() - 1]
             }
+    };
+
+    quote! {
+        impl ComponentType<Enum> for #name {}
+
+        impl CachedComponentData for #name {
+            type UnderlyingType = #name;
+            #cached_component_data_impl
         }
 
         #not_empty_trait_or_error


### PR DESCRIPTION
* Previously you could only create queries where the last type parameters could be optional types, which may or may not be present. This caused a lot of code bloat which was hard to maintain. Through heavy refactoring this bloat has been eliminated and now optional components can be in any order within the tuple list. 

* Immutable components in query's are supported now.

* Iterable implementation got a lot cleaner, easier to maintain and further extendible if desired. We could for example introduce custom wrappers such as Singleton<T> instead of using .term_at(i).singleton()